### PR TITLE
Remove redundant Polygeist build step.

### DIFF
--- a/.github/workflows/enzyme-mlir.yml
+++ b/.github/workflows/enzyme-mlir.yml
@@ -49,21 +49,6 @@ jobs:
         cmake ../Polygeist/llvm-project/llvm -GNinja -DLLVM_ENABLE_PROJECTS="llvm;clang;mlir;openmp" -DCMAKE_BUILD_TYPE=${{ matrix.llbuild }} -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_PARALLEL_LINK_JOBS=2
         ninja -j2
     
-    - name: Cache Polygeist
-      id: cache-polygeist
-      uses: actions/cache@v2
-      with:
-        path: polygeist-build
-        key: ${{ matrix.llbuild }}-${{ matrix.os }}-polygeist-${{ hashFiles('Polygeist/.git/modules/llvm-project/HEAD') }}-${{ hashFiles('Polygeist/.git/refs/heads/main') }}
-
-    - name: Polygeist build
-      if: steps.cache-polygeist.outputs.cache-hit != 'true'
-      run: |
-        mkdir polygeist-build
-        cd polygeist-build
-        cmake ../Polygeist/ -GNinja -DMLIR_DIR=`pwd`/../mlir-build/lib/cmake/mlir -DLLVM_EXTERNAL_LIT=`pwd`/../mlir-build/bin/llvm-lit -DClang_DIR=`pwd`/../mlir-build/lib/cmake/clang -DCMAKE_BUILD_TYPE=${{ matrix.llbuild }}
-        ninja
-
     - name: cmake
       run: |
           cd enzyme && mkdir build


### PR DESCRIPTION
Having tested, the Polygeist caching & build step are being removed s.t. we only

1. Build MLIR
2. Build Enzyme