### PR TITLE
Unify MLIR API with LLVM API

### DIFF
--- a/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
+++ b/enzyme/Enzyme/MLIR/Dialect/EnzymeOps.td
@@ -55,7 +55,7 @@ def ForwardDiffOp : Enzyme_Op<"fwddiff",
   }];
 }
 
-def DiffOp : Enzyme_Op<"diff",
+def AutoDiffOp : Enzyme_Op<"autodiff",
     [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Perform reverse mode AD on a funcop";
   let arguments = (ins FlatSymbolRefAttr:$fn, Variadic<AnyType>:$inputs, ActivityArrayAttr:$activity);

--- a/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
+++ b/enzyme/Enzyme/MLIR/Dialect/Ops.cpp
@@ -53,7 +53,7 @@ ForwardDiffOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return success();
 }
 
-LogicalResult DiffOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+LogicalResult AutoDiffOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // TODO: Verify that the result type is same as the type of the referenced
   // func.func op.
   auto global =

--- a/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/CloneFunction.cpp
@@ -242,10 +242,10 @@ FunctionOpInterface CloneFunctionWithReturns(
       mlir::Value oval = F.getFunctionBody().front().getArgument(i);
       if (constant_args[i] == DIFFE_TYPE_MLIR::CONSTANT)
         constants.insert(oval);
-      else
+      else if (constant_args[i] == DIFFE_TYPE_MLIR::OUT_DIFF)
         nonconstants.insert(oval);
-      if (constant_args[i] == DIFFE_TYPE_MLIR::DUP_ARG ||
-          constant_args[i] == DIFFE_TYPE_MLIR::DUP_NONEED) {
+      else if (constant_args[i] == DIFFE_TYPE_MLIR::DUP_ARG ||
+               constant_args[i] == DIFFE_TYPE_MLIR::DUP_NONEED) {
         mlir::Value val = blk.getArgument(i);
         mlir::Value dval;
         if (i == constant_args.size() - 1)

--- a/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/EnzymeLogicReverse.cpp
@@ -325,7 +325,7 @@ void MEnzymeLogic::initializeShadowValues(
 void MEnzymeLogic::differentiate(MGradientUtilsReverse *gutils,
                                  Region &oldRegion, Region &newRegion,
                                  bool parentRegion,
-                                 buildReturnFunction buildFuncRetrunOp) {
+                                 buildReturnFunction buildFuncReturnOp) {
   gutils->createReverseModeBlocks(oldRegion, newRegion, parentRegion);
 
   SmallVector<mlir::Block *> dominatorToposortBlocks =
@@ -341,7 +341,7 @@ void MEnzymeLogic::differentiate(MGradientUtilsReverse *gutils,
     mapInvertArguments(oBB, reverseBB, gutils);
     handleReturns(oBB, newBB, reverseBB, gutils, parentRegion);
     visitChildren(oBB, reverseBB, gutils);
-    handlePredecessors(oBB, newBB, reverseBB, gutils, buildFuncRetrunOp);
+    handlePredecessors(oBB, newBB, reverseBB, gutils, buildFuncReturnOp);
   }
 }
 
@@ -358,7 +358,7 @@ FunctionOpInterface MEnzymeLogic::CreateReverseDiff(
     llvm_unreachable("Differentiating empty function");
   }
 
-  ReturnTypeMLIR returnValue = ReturnTypeMLIR::Tape;
+  ReturnTypeMLIR returnValue = ReturnTypeMLIR::Args;
   MGradientUtilsReverse *gutils = MGradientUtilsReverse::CreateFromClone(
       *this, mode, width, fn, TA, type_args, retType, /*diffeReturnArg*/ true,
       constants, returnValue, addedType, symbolTable);
@@ -366,13 +366,13 @@ FunctionOpInterface MEnzymeLogic::CreateReverseDiff(
   Region &oldRegion = gutils->oldFunc.getFunctionBody();
   Region &newRegion = gutils->newFunc.getFunctionBody();
 
-  buildReturnFunction buildFuncRetrunOp = [](OpBuilder &builder, Location loc,
+  buildReturnFunction buildFuncReturnOp = [](OpBuilder &builder, Location loc,
                                              SmallVector<Value> retargs) {
     builder.create<func::ReturnOp>(loc, retargs);
     return;
   };
 
-  differentiate(gutils, oldRegion, newRegion, true, buildFuncRetrunOp);
+  differentiate(gutils, oldRegion, newRegion, true, buildFuncReturnOp);
 
   auto nf = gutils->newFunc;
 

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.cpp
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.cpp
@@ -287,11 +287,12 @@ void MGradientUtilsReverse::initInitializationBlock(
 
   for (Value activeval : activevals_) {
     if (auto iface = dyn_cast<AutoDiffTypeInterface>(activeval.getType())) {
-      Location loc = activeval.getLoc();
-      Value gradient = insertInitGradient(activeval, initializationBuilder);
-      Value zero = iface.createNullValue(initializationBuilder, loc);
-      initializationBuilder.create<enzyme::SetOp>(loc, gradient, zero);
-      this->invertedPointersGlobal.map(activeval, gradient);
+      Value zero =
+          iface.createNullValue(initializationBuilder, activeval.getLoc());
+      mapInvertPointer(activeval, zero, initializationBuilder);
+    } else {
+      llvm_unreachable(
+          "Type does not have an associated AutoDiffTypeInterface");
     }
   }
   for (auto const &x : invertedPointers_.getValueMap()) {

--- a/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
+++ b/enzyme/Enzyme/MLIR/Interfaces/GradientUtilsReverse.h
@@ -95,7 +95,8 @@ public:
 
   bool requiresShadow(Type t);
 
-  void initInitializationBlock(BlockAndValueMapping invertedPointers_);
+  void initInitializationBlock(BlockAndValueMapping invertedPointers_,
+                               const SmallPtrSetImpl<mlir::Value> &activevals_);
 
   bool onlyUsedInParentBlock(Value v);
 

--- a/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/EnzymeMLIRPass.cpp
@@ -178,7 +178,7 @@ struct DifferentiatePass : public DifferentiatePassBase<DifferentiatePass> {
 
     {
       SmallVector<Operation *> toLower;
-      op->walk([&](enzyme::DiffOp dop) {
+      op->walk([&](enzyme::AutoDiffOp dop) {
         auto *symbolOp =
             symbolTable.lookupNearestSymbolFrom(dop, dop.getFnAttr());
         auto callableOp = cast<FunctionOpInterface>(symbolOp);
@@ -188,7 +188,7 @@ struct DifferentiatePass : public DifferentiatePassBase<DifferentiatePass> {
       });
 
       for (auto T : toLower) {
-        if (auto F = dyn_cast<enzyme::DiffOp>(T)) {
+        if (auto F = dyn_cast<enzyme::AutoDiffOp>(T)) {
           HandleAutoDiffReverse(symbolTable, F);
         } else {
           llvm_unreachable("Illegal type");

--- a/enzyme/Enzyme/MLIR/Passes/LowerToLLVMEnzyme.cpp
+++ b/enzyme/Enzyme/MLIR/Passes/LowerToLLVMEnzyme.cpp
@@ -100,11 +100,11 @@ void convertMemRefArgument(Location loc, Value primal,
     operands.push_back(memrefPrimal.stride(b, loc, pos));
 }
 
-struct DiffOpLowering : public OpConversionPattern<enzyme::DiffOp> {
-  using OpConversionPattern<enzyme::DiffOp>::OpConversionPattern;
+struct DiffOpLowering : public OpConversionPattern<enzyme::AutoDiffOp> {
+  using OpConversionPattern<enzyme::AutoDiffOp>::OpConversionPattern;
 
   LogicalResult
-  matchAndRewrite(enzyme::DiffOp op, OpAdaptor adaptor,
+  matchAndRewrite(enzyme::AutoDiffOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto moduleOp = op->getParentOfType<ModuleOp>();
     Location loc = op.getLoc();
@@ -263,7 +263,7 @@ struct LowerToLLVMEnzymePass
     populateFuncToLLVMConversionPatterns(typeConverter, patterns);
 
     ConversionTarget target(*context);
-    target.addIllegalOp<enzyme::DiffOp>();
+    target.addIllegalOp<enzyme::AutoDiffOp>();
     target.addLegalDialect<LLVM::LLVMDialect>();
 
     if (failed(applyPartialConversion(getOperation(), target,

--- a/enzyme/Enzyme/MLIR/enzymemlir-opt.cpp
+++ b/enzyme/Enzyme/MLIR/enzymemlir-opt.cpp
@@ -58,6 +58,7 @@ int main(int argc, char **argv) {
   registry.insert<mlir::NVVM::NVVMDialect>();
   registry.insert<mlir::omp::OpenMPDialect>();
   registry.insert<mlir::math::MathDialect>();
+  registry.insert<mlir::linalg::LinalgDialect>();
   registry.insert<DLTIDialect>();
 
   registry.insert<mlir::enzyme::EnzymeDialect>();


### PR DESCRIPTION
There are some discrepancies between APIs with the MLIR/LLVM Enzyme pieces. This PR aims to unify the MLIR API by adding proper support for `enzyme_out` when using scalar values, while also renaming the op to `enzyme.autodiff` for consistency.

There is also a bugfix for `memref.alloc()` shadow values not being zeroed out.